### PR TITLE
fix/tagjson: mitWem without a space

### DIFF
--- a/src/data/standardTags.json
+++ b/src/data/standardTags.json
@@ -20,7 +20,7 @@
   },
   {
     "id": 3,
-    "category": "mit wem",
+    "category": "mitWem",
     "name": "Standard-Tag",
     "singleStandardTags": [
       "alleine",


### PR DESCRIPTION
changed "mit wem" to "mitWem" in standardtags.json