### PR TITLE
component/weathertoggles: fixed style issue when choosing an icon

### DIFF
--- a/src/components/ownComponents/recordPage/SleepActivityWeather.jsx
+++ b/src/components/ownComponents/recordPage/SleepActivityWeather.jsx
@@ -25,7 +25,7 @@ const SleepActivityWeather = () => {
           <ActivitySwitch />
         </div>
         <p>Das Wetter ist...</p>
-        <div className="w-[290px] bg-white p-[22px] text-center mt-5 mb-7 h-[423px/3] overflow-y-scroll">
+        <div className="w-[290px] bg-white p-[22px] text-center mt-5 mb-7 h-[423px/3] overflow-x-scroll">
           {/* Weather */}
           <WeatherToggles />
         </div>

--- a/src/components/ui/toggle.jsx
+++ b/src/components/ui/toggle.jsx
@@ -8,7 +8,7 @@ import { cn } from "@/lib/utils";
 import { forwardRef } from "react";
 
 const toggleVariants = cva(
-  "inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-black data-[state=on]:text-white",
+  "inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors hover:text-muted-foreground focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-black data-[state=on]:text-white",
   {
     variants: {
       variant: {
@@ -40,3 +40,15 @@ const Toggle = forwardRef(({ className, variant, size, ...props }, ref) => (
 Toggle.displayName = TogglePrimitive.Root.displayName;
 
 export { Toggle, toggleVariants };
+
+/* Style Explanations: */
+// hover:text-muted-foreground: Ändert die Textfarbe bei Hover auf eine gemilderte Vordergrundfarbe (muted-foreground).
+// focus-visible:outline-none: Entfernt die Standard-Kontur, wenn das Element fokussiert wird.
+// disabled:pointer-events-none: Deaktiviert Pointer-Events (z. B. Klicks) für das Element, wenn es den Zustand disabled hat.
+
+/* Deleted shadcn ui styles in the cva function: */
+// ring-offset-background: Definiert den ring-offset (den Abstand zwischen einem äußeren Rahmen und dem Element). Dieser bezieht sich auf die Hintergrundfarbe.
+// hover:bg-muted: Ändert den Hintergrund bei Hover (hover) auf eine gemilderte Farbe (muted).
+// focus-visible:ring-2: Fügt einen ring mit 2px Breite hinzu, wenn das Element fokussiert wird.
+// focus-visible:ring-ring: Bestimmt die Farbe des Rings, der bei Fokus erscheint.
+// focus-visible:ring-offset-2: Fügt einen ring-offset mit 2px Breite hinzu, wenn das Element fokussiert wird.

--- a/src/components/ui/toggle.jsx
+++ b/src/components/ui/toggle.jsx
@@ -15,11 +15,13 @@ const toggleVariants = cva(
         default: "bg-transparent",
         outline:
           "border border-input bg-transparent hover:bg-accent hover:text-accent-foreground",
+        selected: "bg-selected-tag",
       },
       size: {
         default: "h-10 px-3",
         sm: "h-9 px-2.5",
         lg: "h-11 px-5",
+        weather: "h-10 w-10",
       },
     },
     defaultVariants: {

--- a/src/components/usedDemoComponents/WeatherToggles.jsx
+++ b/src/components/usedDemoComponents/WeatherToggles.jsx
@@ -34,12 +34,12 @@ export function WeatherToggles() {
     >
       <ToggleGroupItem
         value="sonnig"
-        aria-label="Sunny"
+        aria-label="sonnig"
         className={`${
-          selectedWeather === "sunny" ? "bg-black" : "bg-white"
+          selectedWeather === "sonnig" ? "bg-black" : "bg-white"
         } p-2 rounded-md`}
       >
-        {selectedWeather === "sunny" ? (
+        {selectedWeather === "sonnig" ? (
           <SunnyWhite className="h-8 w-8" />
         ) : (
           <SunnyBlack className="h-8 w-8" />
@@ -48,12 +48,12 @@ export function WeatherToggles() {
 
       <ToggleGroupItem
         value="regnerisch"
-        aria-label="Rainy"
+        aria-label="regnerisch"
         className={`${
-          selectedWeather === "rainy" ? "bg-black" : "bg-white"
+          selectedWeather === "regnerisch" ? "bg-black" : "bg-white"
         } p-2 rounded-md`}
       >
-        {selectedWeather === "rainy" ? (
+        {selectedWeather === "regnerisch" ? (
           <RainyWhite className="h-8 w-8" />
         ) : (
           <RainyBlack className="h-8 w-8" />
@@ -62,12 +62,12 @@ export function WeatherToggles() {
 
       <ToggleGroupItem
         value="bewölkt"
-        aria-label="Cloudy"
+        aria-label="bewölkt"
         className={`${
-          selectedWeather === "cloudy" ? "bg-black" : "bg-white"
+          selectedWeather === "bewölkt" ? "bg-black" : "bg-white"
         } p-2 rounded-md`}
       >
-        {selectedWeather === "cloudy" ? (
+        {selectedWeather === "bewölkt" ? (
           <CloudyWhite className="h-8 w-8" />
         ) : (
           <CloudyBlack className="h-8 w-8" />
@@ -76,12 +76,12 @@ export function WeatherToggles() {
 
       <ToggleGroupItem
         value="stürmisch"
-        aria-label="Stormy"
+        aria-label="stürmisch"
         className={`${
-          selectedWeather === "stormy" ? "bg-black" : "bg-white"
+          selectedWeather === "stürmisch" ? "bg-black" : "bg-white"
         } p-2 rounded-md`}
       >
-        {selectedWeather === "stormy" ? (
+        {selectedWeather === "stürmisch" ? (
           <StormyWhite className="h-8 w-8" />
         ) : (
           <StormyBlack className="h-8 w-8" />
@@ -90,12 +90,12 @@ export function WeatherToggles() {
 
       <ToggleGroupItem
         value="windig"
-        aria-label="Windy"
+        aria-label="windig"
         className={`${
-          selectedWeather === "windy" ? "bg-black" : "bg-white"
+          selectedWeather === "windig" ? "bg-black" : "bg-white"
         } p-2 rounded-md`}
       >
-        {selectedWeather === "windy" ? (
+        {selectedWeather === "windig" ? (
           <WindyWhite className="h-8 w-8" />
         ) : (
           <WindyBlack className="h-8 w-8" />
@@ -104,12 +104,12 @@ export function WeatherToggles() {
 
       <ToggleGroupItem
         value="schneit"
-        aria-label="Snowy"
+        aria-label="schneit"
         className={`${
-          selectedWeather === "snowy" ? "bg-black" : "bg-white"
+          selectedWeather === "schneit" ? "bg-black" : "bg-white"
         } p-2 rounded-md`}
       >
-        {selectedWeather === "snowy" ? (
+        {selectedWeather === "schneit" ? (
           <SnowWhite className="h-8 w-8" />
         ) : (
           <SnowBlack className="h-8 w-8" />

--- a/src/components/usedDemoComponents/WeatherToggles.jsx
+++ b/src/components/usedDemoComponents/WeatherToggles.jsx
@@ -25,92 +25,72 @@ export function WeatherToggles() {
   };
 
   return (
-    <ToggleGroup
-      type="single"
-      value={selectedWeather}
-      onValueChange={handleWeatherChange}
-      aria-label="Select weather"
-      className="grid grid-cols-3 gap-2"
-    >
-      <ToggleGroupItem
-        value="sonnig"
-        aria-label="sonnig"
-        /* className={`${selectedWeather === "sonnig" ? "bg-black" : "bg-white"}`} */
+    <section className="flex flex-col items-center justify-center">
+      <ToggleGroup
+        type="single"
+        size="weather"
+        value={selectedWeather}
+        onValueChange={handleWeatherChange}
+        aria-label="Select weather"
+        className="grid grid-cols-3 gap-6"
       >
-        {selectedWeather === "sonnig" ? (
-          <SunnyWhite className="h-8 w-8" />
-        ) : (
-          <SunnyBlack className="h-8 w-8" />
-        )}
-      </ToggleGroupItem>
+        <ToggleGroupItem
+          value="sonnig"
+          aria-label="sonnig"
 
-      <ToggleGroupItem
-        value="regnerisch"
-        aria-label="regnerisch"
-        /*  className={`${
-          selectedWeather === "regnerisch" ? "bg-black" : "bg-white"
-        }`} */
-      >
-        {selectedWeather === "regnerisch" ? (
-          <RainyWhite className="h-8 w-8" />
-        ) : (
-          <RainyBlack className="h-8 w-8" />
-        )}
-      </ToggleGroupItem>
+          /*  className={`${selectedWeather === "sonnig" ? "bg-black" : "bg-white"}`} */
+        >
+          {selectedWeather === "sonnig" ? (
+            <SunnyWhite className="h-8 w-8" />
+          ) : (
+            <SunnyBlack className="h-8 w-8" />
+          )}
+        </ToggleGroupItem>
 
-      <ToggleGroupItem
-        value="bewölkt"
-        aria-label="bewölkt"
-        /*  className={`${
-          selectedWeather === "bewölkt" ? "bg-black" : "bg-white"
-        } `} */
-      >
-        {selectedWeather === "bewölkt" ? (
-          <CloudyWhite className="h-8 w-8" />
-        ) : (
-          <CloudyBlack className="h-8 w-8" />
-        )}
-      </ToggleGroupItem>
+        <ToggleGroupItem value="regnerisch" aria-label="regnerisch">
+          {selectedWeather === "regnerisch" ? (
+            <RainyWhite className="h-8 w-8" />
+          ) : (
+            <RainyBlack className="h-8 w-8" />
+          )}
+        </ToggleGroupItem>
 
-      <ToggleGroupItem
-        value="stürmisch"
-        aria-label="stürmisch"
-        /*  className={`${
-          selectedWeather === "stürmisch" ? "bg-black" : "bg-white"
-        }`} */
-      >
-        {selectedWeather === "stürmisch" ? (
-          <StormyWhite className="h-8 w-8" />
-        ) : (
-          <StormyBlack className="h-8 w-8" />
-        )}
-      </ToggleGroupItem>
+        <ToggleGroupItem value="bewölkt" aria-label="bewölkt">
+          {selectedWeather === "bewölkt" ? (
+            <CloudyWhite className="h-8 w-8" />
+          ) : (
+            <CloudyBlack className="h-8 w-8" />
+          )}
+        </ToggleGroupItem>
 
-      <ToggleGroupItem
-        value="windig"
-        aria-label="windig"
-        /*  className={`${selectedWeather === "windig" ? "bg-black" : "bg-white"} `} */
-      >
-        {selectedWeather === "windig" ? (
-          <WindyWhite className="h-8 w-8" />
-        ) : (
-          <WindyBlack className="h-8 w-8" />
-        )}
-      </ToggleGroupItem>
+        <ToggleGroupItem value="stürmisch" aria-label="stürmisch">
+          {selectedWeather === "stürmisch" ? (
+            <StormyWhite className="h-8 w-8" />
+          ) : (
+            <StormyBlack className="h-8 w-8" />
+          )}
+        </ToggleGroupItem>
 
-      <ToggleGroupItem
-        value="schneit"
-        aria-label="schneit"
-        /* className={`${
-          selectedWeather === "schneit" ? "bg-black" : "bg-white"
-        } `} */
-      >
-        {selectedWeather === "schneit" ? (
-          <SnowWhite className="h-8 w-8" />
-        ) : (
-          <SnowBlack className="h-8 w-8" />
-        )}
-      </ToggleGroupItem>
-    </ToggleGroup>
+        <ToggleGroupItem value="windig" aria-label="windig">
+          {selectedWeather === "windig" ? (
+            <WindyWhite className="h-8 w-8" />
+          ) : (
+            <WindyBlack className="h-8 w-8" />
+          )}
+        </ToggleGroupItem>
+
+        <ToggleGroupItem
+          value="schneit"
+          aria-label="schneit"
+          /* className={`${selectedWeather === "schneit" ? "bg-black" : "bg-white"}`} */
+        >
+          {selectedWeather === "schneit" ? (
+            <SnowWhite className="h-8 w-8" />
+          ) : (
+            <SnowBlack className="h-8 w-8" />
+          )}
+        </ToggleGroupItem>
+      </ToggleGroup>
+    </section>
   );
 }

--- a/src/components/usedDemoComponents/WeatherToggles.jsx
+++ b/src/components/usedDemoComponents/WeatherToggles.jsx
@@ -30,14 +30,12 @@ export function WeatherToggles() {
       value={selectedWeather}
       onValueChange={handleWeatherChange}
       aria-label="Select weather"
-      className="flex space-x-2"
+      className="grid grid-cols-3 gap-2"
     >
       <ToggleGroupItem
         value="sonnig"
         aria-label="sonnig"
-        className={`${
-          selectedWeather === "sonnig" ? "bg-black" : "bg-white"
-        } p-2 rounded-md`}
+        /* className={`${selectedWeather === "sonnig" ? "bg-black" : "bg-white"}`} */
       >
         {selectedWeather === "sonnig" ? (
           <SunnyWhite className="h-8 w-8" />
@@ -49,9 +47,9 @@ export function WeatherToggles() {
       <ToggleGroupItem
         value="regnerisch"
         aria-label="regnerisch"
-        className={`${
+        /*  className={`${
           selectedWeather === "regnerisch" ? "bg-black" : "bg-white"
-        } p-2 rounded-md`}
+        }`} */
       >
         {selectedWeather === "regnerisch" ? (
           <RainyWhite className="h-8 w-8" />
@@ -63,9 +61,9 @@ export function WeatherToggles() {
       <ToggleGroupItem
         value="bewölkt"
         aria-label="bewölkt"
-        className={`${
+        /*  className={`${
           selectedWeather === "bewölkt" ? "bg-black" : "bg-white"
-        } p-2 rounded-md`}
+        } `} */
       >
         {selectedWeather === "bewölkt" ? (
           <CloudyWhite className="h-8 w-8" />
@@ -77,9 +75,9 @@ export function WeatherToggles() {
       <ToggleGroupItem
         value="stürmisch"
         aria-label="stürmisch"
-        className={`${
+        /*  className={`${
           selectedWeather === "stürmisch" ? "bg-black" : "bg-white"
-        } p-2 rounded-md`}
+        }`} */
       >
         {selectedWeather === "stürmisch" ? (
           <StormyWhite className="h-8 w-8" />
@@ -91,9 +89,7 @@ export function WeatherToggles() {
       <ToggleGroupItem
         value="windig"
         aria-label="windig"
-        className={`${
-          selectedWeather === "windig" ? "bg-black" : "bg-white"
-        } p-2 rounded-md`}
+        /*  className={`${selectedWeather === "windig" ? "bg-black" : "bg-white"} `} */
       >
         {selectedWeather === "windig" ? (
           <WindyWhite className="h-8 w-8" />
@@ -105,9 +101,9 @@ export function WeatherToggles() {
       <ToggleGroupItem
         value="schneit"
         aria-label="schneit"
-        className={`${
+        /* className={`${
           selectedWeather === "schneit" ? "bg-black" : "bg-white"
-        } p-2 rounded-md`}
+        } `} */
       >
         {selectedWeather === "schneit" ? (
           <SnowWhite className="h-8 w-8" />

--- a/src/index.css
+++ b/src/index.css
@@ -67,6 +67,7 @@
     --font-highlight: "Yatra One", sans-serif;
     --selected-subemotion:  /* #FFD9DA */ 358 100% 93%;
     --accent-color:  /* #345995 */ 217 48% 39%;
+    --selected-tag: 0 0% 0%; /* black */
   }
 
   /* Dark Mode */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -37,6 +37,7 @@ module.exports = {
         // Custom Colors:
         "selected-subemotion": "hsl(var(--selected-subemotion))",
         "accent-color": "hsl(var(--accent-color))",
+        "selected-tag": "hsl(var(--selected-tag))",
 
         // Color for specific purposes Extensions:
 


### PR DESCRIPTION
Fixed Style issue with weather toggles (went all black when choosing a weather icon due to unrelated values); improved positions and removed scroll-x due to better overview when seeing all weather icons all at once (made a 3 x 3 grid); also added new variables for toggle styling in config and css file and updated toggle shadcn ui file (changed base styling referring to our needs, added styles we need, removed shadcn styles and wrote comments to explain tailwind utility classes and the deleted utilities)