### PR TITLE
Component/sleeprecord: comment in slider.jsx

### DIFF
--- a/src/components/ownComponents/recordPage/SleepActivityWeather.jsx
+++ b/src/components/ownComponents/recordPage/SleepActivityWeather.jsx
@@ -1,7 +1,5 @@
 //TODO: Request to Backend to check, if there are already any data for the current day => getCheckInsFromToday
 
-//TODO: Check later, when the Recordprocess is connected to the Backend: It also should be possible, that the user can skip this part of the check in or skip selected parts of it (e.g. only check in the weather, but not the sleep time; only change the sleep time, but not the acitvity, etc.) > Does every section need an own skip button? Or is it enough to allow the skip for this whole part of the recordprocess?
-
 // import subcomponents
 import { WeatherToggles } from "@/components/usedDemoComponents/WeatherToggles";
 import { ActivitySwitch } from "@/components/usedDemoComponents/ActivitySwitch";

--- a/src/components/ownComponents/recordPage/SleepRecord.jsx
+++ b/src/components/ownComponents/recordPage/SleepRecord.jsx
@@ -1,6 +1,7 @@
 import { Slider } from "@/components/ui/slider";
 import { useCheckinContext } from "@/utils/CheckinProvider";
 import { useEffect, useState } from "react";
+import UserFeedbackText from "@/components/typo/UserFeedbackText";
 
 // Helper functions:
 
@@ -65,6 +66,13 @@ const SleepRecord = () => {
         onValueChange={handleSliderChange}
         disabled={sleepingHoursRecorded}
       />
+
+      {sleepingHoursRecorded && (
+        <UserFeedbackText
+          content="Du kannst diese Angabe pro Tag nur einmal machen."
+          type="info"
+        />
+      )}
     </div>
   );
 };

--- a/src/components/ownComponents/recordPage/SleepRecord.jsx
+++ b/src/components/ownComponents/recordPage/SleepRecord.jsx
@@ -2,40 +2,50 @@ import { Slider } from "@/components/ui/slider";
 import { useCheckinContext } from "@/utils/CheckinProvider";
 import { useEffect, useState } from "react";
 
-/////// Helper functions: ///////
+// Helper functions:
 
 // convert slider value (0-23) to German hours (17 Uhr - 16 Uhr)
 const sliderToHours = (value) => (value + 17) % 24;
 
 // Calculate sleep duration
 const calculateSleepDuration = (start, end) => {
+  // Local States:
   const startHour = sliderToHours(start);
   const endHour = sliderToHours(end);
   return endHour >= startHour ? endHour - startHour : 24 - startHour + endHour;
 };
 
-/////// Main component: ///////
-
 const SleepRecord = () => {
-  // States:
   const {
     sleepingHours,
     setSleepingHours,
     sleepingHoursRecorded,
     fetchSleepingHours,
   } = useCheckinContext();
-  const [range, setRange] = useState([6, 15]); // default: 23 to 9 (internally plus 17 hours)
+
+  const [range, setRange] = useState([6, 15]); // Default range: 23:00 - 16:00
 
   // Fetch and use today's sleeping hours if available
   useEffect(() => {
     fetchSleepingHours();
-  }, []);
+  }, [fetchSleepingHours]);
+
+  // Set the range based on recorded sleeping hours
+  useEffect(() => {
+    if (sleepingHoursRecorded) {
+      const startHour = (24 + 17 - sleepingHours) % 24;
+      const endHour = 17;
+      setRange([startHour - 17, endHour - 17]);
+    }
+  }, [sleepingHoursRecorded, sleepingHours]);
 
   //   Function handle slider change
   const handleSliderChange = (newRange) => {
-    setRange(newRange);
-    const sleepingRange = calculateSleepDuration(newRange[0], newRange[1]);
-    setSleepingHours(sleepingRange);
+    if (!sleepingHoursRecorded) {
+      setRange(newRange);
+      const sleepingRange = calculateSleepDuration(newRange[0], newRange[1]);
+      setSleepingHours(sleepingRange);
+    }
   };
 
   return (
@@ -45,19 +55,16 @@ const SleepRecord = () => {
           Von {sliderToHours(range[0])} Uhr bis {sliderToHours(range[1])} Uhr
         </p>
       )}
-      <p>
-        {!sleepingHoursRecorded && `(`}
-        {sleepingHours} Stunden{!sleepingHoursRecorded && `)`}
-      </p>
-      {!sleepingHoursRecorded && (
-        <Slider
-          min={0} // After converting: 17:00 Uhr
-          max={22} // After converting: 16:00 Uhr
-          step={1}
-          value={range}
-          onValueChange={handleSliderChange}
-        />
-      )}
+      <p className="p-2">{sleepingHours} Stunden</p>
+
+      <Slider
+        min={0} // After converting: 17:00 Uhr
+        max={22} // After converting: 16:00 Uhr
+        step={1}
+        value={range}
+        onValueChange={handleSliderChange}
+        disabled={sleepingHoursRecorded}
+      />
     </div>
   );
 };

--- a/src/components/ui/slider.jsx
+++ b/src/components/ui/slider.jsx
@@ -8,7 +8,7 @@ const Slider = forwardRef(({ className, ...props }, ref) => (
   <SliderPrimitive.Root
     ref={ref}
     className={cn(
-      "relative flex w-full touch-none select-none items-center",
+      "relative flex w-full touch-none select-none items-center mb-3",
       className
     )}
     {...props}

--- a/src/components/ui/slider.jsx
+++ b/src/components/ui/slider.jsx
@@ -13,6 +13,7 @@ const Slider = forwardRef(({ className, ...props }, ref) => (
     )}
     {...props}
   >
+    {/* Detailed styles for new slider utility classes (i.e. slider-track, etc.) in tailwind-config file */}
     <SliderPrimitive.Track className="slider-track">
       <SliderPrimitive.Range className="slider-range" />
     </SliderPrimitive.Track>

--- a/src/components/ui/slider.jsx
+++ b/src/components/ui/slider.jsx
@@ -1,7 +1,6 @@
 "use client";
 
 import * as SliderPrimitive from "@radix-ui/react-slider";
-
 import { cn } from "@/lib/utils";
 import { forwardRef } from "react";
 
@@ -14,11 +13,11 @@ const Slider = forwardRef(({ className, ...props }, ref) => (
     )}
     {...props}
   >
-    <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-secondary">
-      <SliderPrimitive.Range className="absolute h-full bg-primary" />
+    <SliderPrimitive.Track className="slider-track">
+      <SliderPrimitive.Range className="slider-range" />
     </SliderPrimitive.Track>
-    <SliderPrimitive.Thumb className="block h-5 w-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50" />
-    <SliderPrimitive.Thumb className="block h-5 w-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50" />
+    <SliderPrimitive.Thumb className="slider-thumb" />
+    <SliderPrimitive.Thumb className="slider-thumb" />
   </SliderPrimitive.Root>
 ));
 Slider.displayName = SliderPrimitive.Root.displayName;

--- a/src/index.css
+++ b/src/index.css
@@ -118,6 +118,28 @@
   }
 }
 
+@layer components {
+  /* Add new styles for the Slider component */
+  .slider-track {
+    @apply relative h-2 w-full grow overflow-hidden rounded-full bg-secondary;
+  }
+  .slider-track[data-disabled] {
+    @apply opacity-30;
+  }
+  .slider-range {
+    @apply absolute h-full bg-primary;
+  }
+  .slider-range[data-disabled] {
+    @apply opacity-30;
+  }
+  .slider-thumb {
+    @apply block h-5 w-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none;
+  }
+  .slider-thumb[data-disabled] {
+    @apply opacity-30 bg-slate-200 border-muted;
+  }
+}
+
 /* By using @apply, we ensure that the same styles are consistently applied across multiple elements. If we need to change a style, we can update it in one place (in our CSS variables or utility classes), and it will reflect across all elements using @apply */
 
 /* Instead of using the universal selector (*), we can target specific elements where we want for example the border-border utility to be applied:

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -149,8 +149,24 @@ module.exports = {
               transitionDuration: "0.2s",
             },
           },
+          // Add new utilities for the Slider component
+          ".slider-track": {
+            "&[data-disabled]": {
+              opacity: "1",
+            },
+          },
+          ".slider-range": {
+            "&[data-disabled]": {
+              opacity: "0.5",
+            },
+          },
+          ".slider-thumb": {
+            "&[data-disabled]": {
+              opacity: "0.5",
+            },
+          },
         },
-        ["responsive", "hover"]
+        ["responsive", "hover", "focus", "disabled"]
       );
     },
   ],


### PR DESCRIPTION
fixed the ui with the invisible slider and the non-displayed sleep time by not making the slider disappear completely after specifying a sleep time, but by making it grayed out and non-clickable. The user also gets feedback why this component is no longer editable if he has already made a sleep entry for the respective day.

To find the new slider utilities easier, I wrote a comment in slider.jsx (because there were no default styles for a muted slider from shadcn, I had to extend the slider utility classes in tailwind-config und for reasons of clarity, I then wrote all the detailed styles directly there and not in slider.jsx)